### PR TITLE
Rename `Stream` to `Request`

### DIFF
--- a/src/parser/traits.rs
+++ b/src/parser/traits.rs
@@ -25,7 +25,7 @@ use crate::{response::prelude::*, stream::traits::StreamSlice};
 
 pub trait Parser {
     /// The input [`Stream`] iterated by the parser
-    type Input: Stream;
+    type Input: Request;
     /// The output [`Response`] returned by the parser
     type Output: Response;
 


### PR DESCRIPTION
This change conforms more closely to networking; it increases familiarity of the system to users already familiar with networking topics.

On the web: a `Request` gets sent from a client, _requesting_ the server for resources, and the server then sends back a `Response` fulfilling their request.

For this parser: a `Request` gets sent to the parser, _requesting_ the parser to parse their source code, and the parser then sends back a `Response` once parsing has been completed.